### PR TITLE
Flatten API

### DIFF
--- a/lib/clients/authenticated.js
+++ b/lib/clients/authenticated.js
@@ -1,44 +1,30 @@
 const { signRequest } = require('../../lib/request_signer');
-const request = require('request');
-
 const PublicClient = require('./public.js');
 
 class AuthenticatedClient extends PublicClient {
-  constructor(key, b64secret, passphrase, apiURI) {
-    super('', apiURI);
-    this.key = key;
-    this.b64secret = b64secret;
-    this.passphrase = passphrase;
+  constructor(key, b64secret, passphrase, apiURI, rateLimit = 5) {
+    super(undefined, apiURI, rateLimit);
+    this._key = key;
+    this._b64secret = b64secret;
+    this._passphrase = passphrase;
   }
 
-  request(method, uriParts, opts = {}, callback) {
-    if (!callback && typeof opts == 'function') {
-      callback = opts;
-      opts = {};
-    }
-
-    const relativeURI = this.makeRelativeURI(uriParts);
+  _request({ method, uri, queries = {}, headers = {} }) {
+    const arg = arguments[0];
+    arg.queries = queries;
+    arg.headers = headers;
     method = method.toUpperCase();
-    Object.assign(opts, {
-      method: method,
-      uri: this.makeAbsoluteURI(relativeURI),
-    });
-
-    this.addHeaders(opts, this._getSignature(method, relativeURI, opts));
-    return new Promise((resolve, reject) => {
-      request(opts, this.makeRequestCallback(callback, resolve, reject));
-    });
+    Object.assign(headers, this._getSignatureHeaders(method, uri, queries));
+    return super._request(arg);
   }
 
-  _getSignature(method, relativeURI, opts) {
+  _getSignatureHeaders(method, relativeURI, queries, body) {
     const auth = {
-      key: this.key,
-      secret: this.b64secret,
-      passphrase: this.passphrase,
+      key: this._key,
+      secret: this._b64secret,
+      passphrase: this._passphrase,
     };
-    const sig = signRequest(auth, method, relativeURI, opts);
-
-    if (opts.body) opts.body = JSON.stringify(opts.body);
+    const sig = signRequest(auth, method, relativeURI, queries, body);
     return {
       'CB-ACCESS-KEY': sig.key,
       'CB-ACCESS-SIGN': sig.signature,
@@ -48,11 +34,11 @@ class AuthenticatedClient extends PublicClient {
   }
 
   getAccounts(callback) {
-    return this.get(['accounts'], callback);
+    return this._get({ uri: `/accounts`, callback });
   }
 
   getAccount(accountID, callback) {
-    return this.get(['accounts', accountID], callback);
+    return this._get({ uri: `/accounts/${accountID}`, callback });
   }
 
   getAccountHistory(accountID, args = {}, callback) {
@@ -61,7 +47,11 @@ class AuthenticatedClient extends PublicClient {
       args = {};
     }
 
-    return this.get(['accounts', accountID, 'ledger'], { qs: args }, callback);
+    return this._get({
+      uri: `/accounts/${accountID}/ledger`,
+      queries: args,
+      callback,
+    });
   }
 
   getAccountHolds(accountID, args = {}, callback) {
@@ -70,7 +60,11 @@ class AuthenticatedClient extends PublicClient {
       args = {};
     }
 
-    return this.get(['accounts', accountID, 'holds'], { qs: args }, callback);
+    return this._get({
+      uri: `/accounts/${accountID}/holds`,
+      queries: args,
+      callback,
+    });
   }
 
   _placeOrder(params, callback) {
@@ -80,7 +74,7 @@ class AuthenticatedClient extends PublicClient {
 
     this._requireParams(params, requiredParams);
 
-    return this.post(['orders'], { body: params }, callback);
+    return this._post({ uri: '/orders', body: params, callback });
   }
 
   buy(params, callback) {
@@ -94,7 +88,7 @@ class AuthenticatedClient extends PublicClient {
   }
 
   getTrailingVolume(callback) {
-    return this.get(['users', 'self', 'trailing-volume'], {}, callback);
+    return this._get({ uri: `/users/${self}/trailing-volume`, callback });
   }
 
   cancelOrder(orderID, callback) {
@@ -104,11 +98,11 @@ class AuthenticatedClient extends PublicClient {
       return Promise.reject(err);
     }
 
-    return this.delete(['orders', orderID], callback);
+    return this._delete({ uri: `/orders/${orderID}`, callback });
   }
 
   cancelOrders(callback) {
-    return this.delete(['orders'], callback);
+    return this._delete({ uri: `/orders`, callback });
   }
 
   // temp over ride public call to get Product Orderbook
@@ -118,7 +112,11 @@ class AuthenticatedClient extends PublicClient {
       args = {};
     }
 
-    return this.get(['products', productId, 'book'], { qs: args }, callback);
+    return this._get({
+      uri: `/products/${productId}/book`,
+      queries: args,
+      callback,
+    });
   }
 
   cancelAllOrders(args = {}, callback) {
@@ -126,33 +124,28 @@ class AuthenticatedClient extends PublicClient {
       callback = args;
       args = {};
     }
-
-    const opts = { qs: args };
     const totalDeletedOrders = [];
 
-    return function deleteNext() {
-      return new Promise((resolve, reject) => {
-        this.delete(['orders'], opts, (err, response, data) => {
-          if (err || data === null)
-            reject(err || 'Could not delete all orders');
-          else resolve([response, data]);
-        }).catch(() => {}); // handled by callback instead
+    const deleteNext = () => {
+      return this._delete({
+        uri: `/orders`,
+        queries: args,
       })
-        .then(values => {
-          let [response, data] = values;
+        .then(data => {
           totalDeletedOrders.push(...data);
-          if (data.length) return deleteNext.call(this);
-          else return response;
-        })
-        .then(response => {
-          if (callback) callback(undefined, response, totalDeletedOrders);
-          return totalDeletedOrders;
+          if (data.length) return deleteNext();
+          else {
+            if (callback) callback(undefined, totalDeletedOrders);
+            return totalDeletedOrders;
+          }
         })
         .catch(err => {
           if (callback) callback(err);
           throw err;
         });
-    }.call(this);
+    };
+
+    return deleteNext();
   }
 
   getOrders(args = {}, callback) {
@@ -161,7 +154,7 @@ class AuthenticatedClient extends PublicClient {
       args = {};
     }
 
-    return this.get(['orders'], { qs: args }, callback);
+    return this._get({ uri: `/orders`, queries: args, callback });
   }
 
   getOrder(orderID, callback) {
@@ -171,7 +164,7 @@ class AuthenticatedClient extends PublicClient {
       return Promise.reject(err);
     }
 
-    return this.get(['orders', orderID], callback);
+    return this._get({ uri: `/orders/${orderID}`, callback });
   }
 
   getFills(args = {}, callback) {
@@ -180,31 +173,30 @@ class AuthenticatedClient extends PublicClient {
       args = {};
     }
 
-    return this.get(['fills'], { qs: args }, callback);
+    return this._get({ uri: `/fills`, queries: args, callback });
   }
 
   getFundings(callback) {
-    return this.get(['funding'], callback);
+    return this._get({ uri: `/funding`, callback });
   }
 
   repay(params, callback) {
     this._requireParams(params, ['amount', 'currency']);
-    return this.post(['funding/repay'], { body: params }, callback);
+    return this._post({ uri: `/funding/repay`, body: params, callback });
   }
 
   marginTransfer(params, callback) {
-    this._requireParams(params, [
-      'margin_profile_id',
-      'type',
-      'currency',
-      'amount',
-    ]);
-    return this.post(['profiles/margin-transfer'], { body: params }, callback);
+    this._requireParams(params, ['margin_profile_id', 'type', 'currency', 'amount']);
+    return this._post({
+      uri: `/profiles/margin-transfer`,
+      body: params,
+      callback,
+    });
   }
 
   closePosition(params, callback) {
     this._requireParams(params, ['repay_only']);
-    return this.post(['position/close'], { body: params }, callback);
+    return this._post({ uri: `/position/close`, body: params, callback });
   }
 
   deposit(params, callback) {
@@ -219,7 +211,7 @@ class AuthenticatedClient extends PublicClient {
 
   _transferFunds(params, callback) {
     this._requireParams(params, ['type', 'amount', 'coinbase_account_id']);
-    return this.post(['transfers'], { body: params }, callback);
+    return this._post({ uri: `/transfers`, body: params, callback });
   }
 
   _requireParams(params, required) {

--- a/lib/clients/public.js
+++ b/lib/clients/public.js
@@ -1,81 +1,75 @@
-const request = require('request');
 const { Readable } = require('stream');
+const agent = require('superagent-use')(require('superagent'));
+const agentPrefix = require('superagent-prefix');
 
 class PublicClient {
   constructor(productID = 'BTC-USD', apiURI = 'https://api.gdax.com') {
-    this.productID = productID;
-    this.apiURI = apiURI;
-    this.API_LIMIT = 100;
+    agent.use(agentPrefix(apiURI));
+
+    this._productID = productID;
+    this._API_LIMIT = 100;
   }
 
-  get(...args) {
-    return this.request('get', ...args);
+  _get(args) {
+    return this._request(Object.assign({ method: 'get' }, args));
   }
-  put(...args) {
-    return this.request('put', ...args);
+  _put(args) {
+    return this._request(Object.assign({ method: 'put' }, args));
   }
-  post(...args) {
-    return this.request('post', ...args);
+  _post(args) {
+    return this._request(Object.assign({ method: 'post' }, args));
   }
-  delete(...args) {
-    return this.request('delete', ...args);
-  }
-
-  addHeaders(obj, additional) {
-    obj.headers = obj.headers || {};
-    return Object.assign(
-      obj.headers,
-      {
-        'User-Agent': 'gdax-node-client',
-        Accept: 'application/json',
-        'Content-Type': 'application/json',
-      },
-      additional
-    );
+  _delete(args) {
+    return this._request(Object.assign({ method: 'delete' }, args));
   }
 
-  makeRelativeURI(parts) {
-    return '/' + parts.join('/');
+  _requestParamsToObj(...args) {
+    if (args.length == 1 && typeof args[0] == 'object') return args[0];
+
+    let obj = {};
+    ['uri', 'queries', 'headers', 'body', 'callback'].forEach((param, i) => {
+      obj[param] = args[i];
+    });
+    return obj;
   }
 
-  makeAbsoluteURI(relativeURI) {
-    return this.apiURI + relativeURI;
-  }
+  _request({
+    method,
+    uri,
+    queries = {},
+    headers = {},
+    body = {},
+    callback = () => {},
+  }) {
+    method = method.toLowerCase();
 
-  makeRequestCallback(callback, resolve, reject) {
-    return function(err, response, data) {
-      try {
-        data = JSON.parse(data);
-      } catch (e) {
-        data = null;
-      }
-      if (typeof callback == 'function') callback(err, response, data);
-      if (err) reject(err);
-      if (data === null)
-        reject(new Error('Response could not be parsed as JSON'));
-      else resolve(data);
-    };
-  }
+    let request = agent
+      [method](uri)
+      .set('User-Agent', 'gdax-node-client')
+      .query(queries)
+      .accept('json');
 
-  request(method, uriParts, opts = {}, callback) {
-    if (!callback && typeof opts === 'function') {
-      callback = opts;
-      opts = {};
+    for (let h in headers) {
+      request = request.set(h, headers[h]);
     }
 
-    Object.assign(opts, {
-      method: method.toUpperCase(),
-      uri: this.makeAbsoluteURI(this.makeRelativeURI(uriParts)),
-    });
-    this.addHeaders(opts);
-    // console.log('making request=', opts);
-    return new Promise((resolve, reject) => {
-      request(opts, this.makeRequestCallback(callback, resolve, reject));
-    });
+    if (method == 'put' || method == 'post') {
+      request = request.type('json').send(body);
+    }
+
+    return request
+      .then(response => {
+        callback(undefined, response.body);
+        return response.body;
+      })
+      .catch(error => {
+        callback(error);
+        throw error;
+      });
   }
 
   getProducts(callback) {
-    return this.get(['products'], callback);
+    return this._get({ uri: '/products', callback });
   }
 
   getProductOrderBook(args = {}, callback) {
@@ -84,15 +78,15 @@ class PublicClient {
       args = {};
     }
 
-    return this.get(
-      ['products', this.productID, 'book'],
-      { qs: args },
-      callback
-    );
+    return this._get({
+      uri: `/products/${this._productID}/book`,
+      queries: args,
+      callback,
+    });
   }
 
   getProductTicker(callback) {
-    return this.get(['products', this.productID, 'ticker'], callback);
+    return this._get({ uri: `/products/${this._productID}/ticker`, callback });
   }
 
   getProductTrades(args = {}, callback) {
@@ -100,87 +94,65 @@ class PublicClient {
       callback = args;
       args = {};
     }
-    return this.get(
-      ['products', this.productID, 'trades'],
-      { qs: args },
-      callback
-    );
+    return this._get({
+      uri: `/products/${this._productID}/trades`,
+      queries: args,
+      callback,
+    });
   }
 
   getProductTradeStream(tradesFrom, tradesTo) {
-    let shouldStop = null;
+    let stopFn = () => false;
 
     if (typeof tradesTo === 'function') {
-      shouldStop = tradesTo;
-      tradesTo = null;
+      stopFn = tradesTo;
+      tradesTo = Infinity;
     }
 
-    const rs = new Readable({ objectMode: true });
+    const stream = new Readable({ objectMode: true });
     let started = false;
 
-    rs._read = () => {
+    stream._read = () => {
       if (!started) {
         started = true;
-        fetchTrades.bind(this)(rs, tradesFrom, tradesTo, shouldStop, 0);
+        fetchTrades.call(this, tradesFrom, tradesTo);
       }
     };
 
-    return rs;
+    return stream;
 
-    function fetchTrades(stream, tradesFrom, tradesTo, shouldStop) {
-      let after = tradesFrom + this.API_LIMIT + 1;
-      let loop = true;
+    function fetchTrades(tradesFrom, tradesTo) {
+      let after = tradesFrom + this._API_LIMIT + 1;
 
-      if (tradesTo && tradesTo <= after) {
-        after = tradesTo;
-        loop = false;
-      }
+      if (tradesTo < after) after = tradesTo;
 
-      let opts = { before: tradesFrom, after: after, limit: this.API_LIMIT };
+      let opts = { before: tradesFrom, after: after, limit: this._API_LIMIT };
 
-      this.getProductTrades(opts, (err, resp, data) => {
-        if (err) {
-          stream.emit('error', err);
-          return;
-        }
+      this.getProductTrades(opts)
+        .then(data => {
+          let trade;
 
-        if (resp.statusCode === 429) {
-          // rate-limited, try again
-          setTimeout(() => {
-            fetchTrades.call(this, stream, tradesFrom, tradesTo, shouldStop);
-          }, 900);
-          return;
-        }
+          while (data.length) {
+            trade = data.pop();
+            trade.trade_id = parseInt(trade.trade_id);
 
-        if (resp.statusCode !== 200) {
-          stream.emit(
-            'error',
-            new Error('Encountered status code ' + resp.statusCode)
-          );
-        }
+            if (stopFn(trade)) {
+              stream.push(null);
+              return;
+            }
 
-        for (var i = data.length - 1; i >= 0; i--) {
-          if (shouldStop && shouldStop(data[i])) {
-            stream.push(null);
-            return;
+            if (trade.trade_id >= tradesTo - 1) {
+              stream.push(trade);
+              stream.push(null);
+              return;
+            }
+
+            stream.push(trade);
           }
 
-          stream.push(data[i]);
-        }
-
-        if (!loop) {
-          stream.push(null);
-          return;
-        }
-
-        fetchTrades.call(
-          this,
-          stream,
-          tradesFrom + this.API_LIMIT,
-          tradesTo,
-          shouldStop
-        );
-      });
+          fetchTrades.call(this, trade.trade_id, tradesTo);
+        })
+        .catch(err => stream.emit('error', err));
     }
   }
 
@@ -189,23 +161,23 @@ class PublicClient {
       callback = args;
       args = {};
     }
-    return this.get(
-      ['products', this.productID, 'candles'],
-      { qs: args },
-      callback
-    );
+    return this._get({
+      uri: `/products/${this._productID}/candles`,
+      queries: args,
+      callback,
+    });
   }
 
   getProduct24HrStats(callback) {
-    return this.get(['products', this.productID, 'stats'], callback);
+    return this._get({ uri: `/products/${this._productID}/stats`, callback });
   }
 
   getCurrencies(callback) {
-    return this.get(['currencies'], callback);
+    return this._get({ uri: '/currencies', callback });
   }
 
   getTime(callback) {
-    return this.get(['time'], callback);
+    return this._get({ uri: '/time', callback });
   }
 }
 

--- a/lib/orderbook.js
+++ b/lib/orderbook.js
@@ -77,7 +77,7 @@ class Orderbook {
     const tree = this._getTree(order.side);
     const node = tree.find({ price: order.price });
     assert(node);
-    const orders = node.orders;
+    const { orders } = node;
 
     orders.splice(orders.indexOf(order), 1);
 

--- a/lib/orderbook_sync.js
+++ b/lib/orderbook_sync.js
@@ -19,6 +19,7 @@ class OrderbookSync extends WebsocketClient {
     this._queues = {}; // []
     this._sequences = {}; // -1
     this._public_clients = {};
+    this._apiURI = apiURI;
     this.books = {};
 
     this.productIDs.forEach(productID => {
@@ -51,28 +52,16 @@ class OrderbookSync extends WebsocketClient {
       this.authenticatedClient.getProductOrderBook(args, productID, cb);
     } else {
       if (!this._public_clients[productID]) {
-        this._public_clients[productID] = new PublicClient(
-          productID,
-          this.apiURI
-        );
+        this._public_clients[productID] = new PublicClient(productID, this._apiURI);
       }
       this._public_clients[productID].getProductOrderBook(args, cb.bind(this));
     }
 
-    function cb(err, response, body) {
-      if (err) {
-        throw new Error('Failed to load orderbook: ' + err);
-      }
+    function cb(err, data) {
+      if (err) throw new Error('Failed to load orderbook: ' + err);
 
-      if (response.statusCode !== 200) {
-        throw new Error('Failed to load orderbook: ' + response.statusCode);
-      }
+      if (!this.books[productID]) return;
 
-      if (!this.books[productID]) {
-        return;
-      }
-
-      const data = JSON.parse(response.body);
       this.books[productID].state(data);
 
       this._sequences[productID] = data.sequence;
@@ -82,7 +71,7 @@ class OrderbookSync extends WebsocketClient {
   }
 
   processMessage(data) {
-    const product_id = data.product_id;
+    const { product_id } = data;
 
     if (this._sequences[product_id] == -1) {
       // Resync is in process

--- a/lib/request_signer.js
+++ b/lib/request_signer.js
@@ -3,26 +3,28 @@ const crypto = require('crypto');
 const querystring = require('querystring');
 /**
  Signs request messages for authenticated requests to GDAX
- * @param auth {object} hash containing key, secret and passphrase
- * @param method {string} The REST method to use
- * @param path {string} The request path, e.g. /products/BTC-USD/ticker
- * @param options {object} An optional object containing one of
- * @param options.body {object} A hash of body properties
- * @param options.qs {object} A hash of query string parameters
+ * @param {object} auth - hash containing key, secret and passphrase
+ * @param {string} method - The REST method to use
+ * @param {string} path - The request path, e.g. /products/BTC-USD/ticker
+ * @param {object} queries - An optional object containing one of
+ * @param {object} body - An object used as JSON payload for a POST or PUT request
  * @returns {{key: string, signature: *, timestamp: number, passphrase: string}}
  */
-module.exports.signRequest = function(auth, method, path, options = {}) {
+module.exports.signRequest = function(auth, method, path, queries, body) {
+  let queriesString = '';
+  let bodyString = '';
+
+  if (queries && typeof queries == 'object')
+    queriesString = '?' + querystring.stringify(queries);
+  if (body && typeof body == 'object') bodyString = JSON.stringify(body);
+
   const timestamp = Date.now() / 1000;
-  let body = '';
-  if (options.body) {
-    body = JSON.stringify(options.body);
-  } else if (options.qs && Object.keys(options.qs).length !== 0) {
-    body = '?' + querystring.stringify(options.qs);
-  }
-  const what = timestamp + method.toUpperCase() + path + body;
+
+  const what = timestamp + method.toUpperCase() + path + queriesString + bodyString;
   const key = Buffer(auth.secret, 'base64');
   const hmac = crypto.createHmac('sha256', key);
   const signature = hmac.update(what).digest('base64');
+
   return {
     key: auth.key,
     signature: signature,

--- a/package.json
+++ b/package.json
@@ -21,17 +21,19 @@
     }
   ],
   "dependencies": {
-    "bintrees": "1.0.1",
-    "num": "0.3.0",
-    "request": "2.81.0",
-    "ws": "3.0.0"
+    "bintrees": "^1.0.1",
+    "num": "^0.3.0",
+    "superagent": "^3.5.2",
+    "superagent-prefix": "0.0.2",
+    "superagent-use": "^0.1.0",
+    "ws": "^3.0.0"
   },
   "description": "Client for the GDAX API",
   "devDependencies": {
     "eslint": "^4.0.0",
     "husky": "^0.13.4",
-    "lint-staged": "^3.6.1",
-    "mocha": "3.4.2",
+    "lint-staged": "^4.0.0",
+    "mocha": "^3.4.2",
     "nock": "9.0.13",
     "prettier": "^1.4.4"
   },
@@ -65,7 +67,7 @@
   },
   "lint-staged": {
     "*.js": [
-      "prettier --single-quote --trailing-comma es5 --write",
+      "prettier --single-quote --trailing-comma es5 --print-width 86 --write",
       "git add"
     ]
   }

--- a/tests/authenticated.spec.js
+++ b/tests/authenticated.spec.js
@@ -14,7 +14,7 @@ const authClient = new Gdax.AuthenticatedClient(key, secret, passphrase);
 suite('AuthenticatedClient', () => {
   afterEach(() => nock.cleanAll());
 
-  test('._getSignature()', function() {
+  test('._getSignature()', () => {
     const method = 'PUT';
     const relativeURI = '/orders';
     const opts = {
@@ -22,7 +22,7 @@ suite('AuthenticatedClient', () => {
       uri: 'https://api.gdax.com/orders',
     };
 
-    const sig = authClient._getSignature(method, relativeURI, opts);
+    const sig = authClient._getSignatureHeaders(method, relativeURI, opts);
 
     assert.equal(sig['CB-ACCESS-KEY'], key);
     assert.equal(sig['CB-ACCESS-PASSPHRASE'], passphrase);
@@ -31,7 +31,7 @@ suite('AuthenticatedClient', () => {
     assert(sig['CB-ACCESS-SIGN']);
   });
 
-  test('.getAccount()', done => {
+  test('.getAccount()', () => {
     const expectedResponse = {
       id: 'a1b2c3d4',
       balance: '1.100',
@@ -46,7 +46,7 @@ suite('AuthenticatedClient', () => {
       .reply(200, expectedResponse);
 
     let cbtest = new Promise((resolve, reject) =>
-      authClient.getAccount('test-id', (err, resp, data) => {
+      authClient.getAccount('test-id', (err, data) => {
         if (err) reject(err);
         assert.deepEqual(data, expectedResponse);
         resolve();
@@ -57,12 +57,10 @@ suite('AuthenticatedClient', () => {
       .getAccount('test-id')
       .then(data => assert.deepEqual(data, expectedResponse));
 
-    Promise.all([cbtest, promisetest])
-      .then(() => done())
-      .catch(err => assert.ifError(err) || assert.fail());
+    return Promise.all([cbtest, promisetest]);
   });
 
-  test('.getAccounts()', done => {
+  test('.getAccounts()', () => {
     const expectedResponse = [
       {
         id: 'a1b2c3d4',
@@ -73,13 +71,10 @@ suite('AuthenticatedClient', () => {
       },
     ];
 
-    nock(EXCHANGE_API_URL)
-      .get('/accounts')
-      .times(2)
-      .reply(200, expectedResponse);
+    nock(EXCHANGE_API_URL).get('/accounts').times(2).reply(200, expectedResponse);
 
     let cbtest = new Promise((resolve, reject) =>
-      authClient.getAccounts((err, resp, data) => {
+      authClient.getAccounts((err, data) => {
         if (err) reject(err);
         assert.deepEqual(data, expectedResponse);
         resolve();
@@ -90,12 +85,10 @@ suite('AuthenticatedClient', () => {
       .getAccounts()
       .then(data => assert.deepEqual(data, expectedResponse));
 
-    Promise.all([cbtest, promisetest])
-      .then(() => done())
-      .catch(err => assert.ifError(err) || assert.fail());
+    return Promise.all([cbtest, promisetest]);
   });
 
-  test('.getAccountHistory()', done => {
+  test('.getAccountHistory()', () => {
     const expectedResponse = [
       {
         id: '100',
@@ -117,7 +110,7 @@ suite('AuthenticatedClient', () => {
       .reply(200, expectedResponse);
 
     let cbtest = new Promise((resolve, reject) =>
-      authClient.getAccountHistory('test-id', (err, resp, data) => {
+      authClient.getAccountHistory('test-id', (err, data) => {
         if (err) reject(err);
         assert.deepEqual(data, expectedResponse);
         resolve();
@@ -128,12 +121,10 @@ suite('AuthenticatedClient', () => {
       .getAccountHistory('test-id')
       .then(data => assert.deepEqual(data, expectedResponse));
 
-    Promise.all([cbtest, promisetest])
-      .then(() => done())
-      .catch(err => assert.ifError(err) || assert.fail());
+    return Promise.all([cbtest, promisetest]);
   });
 
-  test('.getAccountHolds()', done => {
+  test('.getAccountHolds()', () => {
     const expectedResponse = [
       {
         id: '82dcd140-c3c7-4507-8de4-2c529cd1a28f',
@@ -152,7 +143,7 @@ suite('AuthenticatedClient', () => {
       .reply(200, expectedResponse);
 
     let cbtest = new Promise((resolve, reject) => {
-      authClient.getAccountHolds('test-id', (err, resp, data) => {
+      authClient.getAccountHolds('test-id', (err, data) => {
         if (err) reject(err);
         assert.deepEqual(data, expectedResponse);
         resolve();
@@ -163,12 +154,10 @@ suite('AuthenticatedClient', () => {
       .getAccountHolds('test-id')
       .then(data => assert.deepEqual(data, expectedResponse));
 
-    Promise.all([cbtest, promisetest])
-      .then(() => done())
-      .catch(err => assert.ifError(err) || assert.fail());
+    return Promise.all([cbtest, promisetest]);
   });
 
-  test('.buy()', done => {
+  test('.buy()', () => {
     const order = {
       size: '10',
       product_id: 'BTC-USD',
@@ -188,7 +177,7 @@ suite('AuthenticatedClient', () => {
       .reply(200, expectedResponse);
 
     let cbtest = new Promise((resolve, reject) => {
-      authClient.buy(order, (err, resp, data) => {
+      authClient.buy(order, (err, data) => {
         if (err) reject(err);
         assert.deepEqual(data, expectedResponse);
         resolve();
@@ -199,12 +188,10 @@ suite('AuthenticatedClient', () => {
       .buy(order)
       .then(data => assert.deepEqual(data, expectedResponse));
 
-    Promise.all([cbtest, promisetest])
-      .then(() => done())
-      .catch(err => assert.ifError(err) || assert.fail());
+    return Promise.all([cbtest, promisetest]);
   });
 
-  test('.sell()', done => {
+  test('.sell()', () => {
     const order = {
       size: '10',
       product_id: 'BTC-USD',
@@ -224,7 +211,7 @@ suite('AuthenticatedClient', () => {
       .reply(200, expectedResponse);
 
     let cbtest = new Promise((resolve, reject) => {
-      authClient.sell(order, (err, resp, data) => {
+      authClient.sell(order, (err, data) => {
         if (err) reject(err);
         assert.deepEqual(data, expectedResponse);
         resolve();
@@ -235,43 +222,32 @@ suite('AuthenticatedClient', () => {
       .sell(order)
       .then(data => assert.deepEqual(data, expectedResponse));
 
-    Promise.all([cbtest, promisetest])
-      .then(() => done())
-      .catch(err => assert.ifError(err) || assert.fail());
+    return Promise.all([cbtest, promisetest]);
   });
 
-  test('.getProductOrderBook()', done => {
-    nock(EXCHANGE_API_URL)
-      .get('/products/BTC-USD/book?level=3')
-      .times(2)
-      .reply(200, {
-        asks: [],
-        bids: [],
-      });
+  test('.getProductOrderBook()', () => {
+    nock(EXCHANGE_API_URL).get('/products/BTC-USD/book?level=3').times(2).reply(200, {
+      asks: [],
+      bids: [],
+    });
 
     let cbtest = new Promise((resolve, reject) => {
-      authClient.getProductOrderBook(
-        { level: 3 },
-        'BTC-USD',
-        (err, resp, data) => {
-          if (err) reject(err);
-          assert(data);
-          resolve();
-        }
-      );
+      authClient.getProductOrderBook({ level: 3 }, 'BTC-USD', (err, data) => {
+        if (err) reject(err);
+        assert(data);
+        resolve();
+      });
     });
 
     let promisetest = authClient
       .getProductOrderBook({ level: 3 }, 'BTC-USD')
       .then(data => assert(data));
 
-    Promise.all([cbtest, promisetest])
-      .then(() => done())
-      .catch(err => assert.ifError(err) || assert.fail());
+    return Promise.all([cbtest, promisetest]);
   });
 
   suite('.cancelAllOrders()', () => {
-    test('cancels all orders', done => {
+    test('cancels all orders', () => {
       const cancelledOrdersOne = [
         'deleted-id-1',
         'deleted-id-2',
@@ -285,9 +261,7 @@ suite('AuthenticatedClient', () => {
         'deleted-id-7',
         'deleted-id-8',
       ];
-      const totalExpectedDeleted = cancelledOrdersOne.concat(
-        cancelledOrdersTwo
-      );
+      const totalExpectedDeleted = [...cancelledOrdersOne, ...cancelledOrdersTwo];
 
       const nockSetup = () => {
         // first list of Id's that just got cancelled
@@ -306,7 +280,7 @@ suite('AuthenticatedClient', () => {
       nockSetup();
 
       let cbtest = new Promise((resolve, reject) => {
-        authClient.cancelAllOrders((err, resp, data) => {
+        authClient.cancelAllOrders((err, data) => {
           if (err) reject(err);
           else assert.deepEqual(data, totalExpectedDeleted);
           resolve();
@@ -318,30 +292,29 @@ suite('AuthenticatedClient', () => {
         .then(() => authClient.cancelAllOrders())
         .then(data => assert.deepEqual(data, totalExpectedDeleted));
 
-      Promise.all([cbtest, promisetest])
-        .then(() => done())
-        .catch(err => assert.ifError(err) || assert.fail());
+      return Promise.all([cbtest, promisetest]);
     });
 
-    test('handles errors', done => {
+    test('handles errors', () => {
       nock(EXCHANGE_API_URL).delete('/orders').reply(404, null);
 
-      authClient
-        .cancelAllOrders(function(err, resp, data) {
+      return authClient
+        .cancelAllOrders((err, data) => {
           assert(err);
+          assert.ifError(data);
         })
         .then(() => assert.fail(`Didn't throw error`))
-        .catch(err => assert(err))
-        .then(() => done());
+        .catch(err => assert(err));
     });
   });
 
   suite('.cancelOrder()', () => {
-    test('requires orderID', done => {
-      let cbtest = new Promise((resolve, reject) => {
+    test('requires orderID', () => {
+      let cbtest = new Promise(resolve => {
         authClient
-          .cancelOrder((err, resp, data) => {
+          .cancelOrder((err, data) => {
             assert(err);
+            assert.ifError(data);
             resolve();
           })
           .catch(() => {});
@@ -352,12 +325,10 @@ suite('AuthenticatedClient', () => {
         .catch(err => !assert(err) && true)
         .then(val => assert.strictEqual(val, true));
 
-      Promise.all([cbtest, promisetest])
-        .then(() => done())
-        .catch(err => assert.ifError(err) || assert.fail());
+      return Promise.all([cbtest, promisetest]);
     });
 
-    test('cancels order', done => {
+    test('cancels order', () => {
       const expectedResponse = [
         {
           id: 'd50ec984-77a8-460a-b958-66f114b0de9b',
@@ -373,13 +344,10 @@ suite('AuthenticatedClient', () => {
         },
       ];
 
-      nock(EXCHANGE_API_URL)
-        .get('/orders')
-        .times(2)
-        .reply(200, expectedResponse);
+      nock(EXCHANGE_API_URL).get('/orders').times(2).reply(200, expectedResponse);
 
       let cbtest = new Promise((resolve, reject) => {
-        authClient.getOrders((err, resp, data) => {
+        authClient.getOrders((err, data) => {
           if (err) reject(err);
           assert.deepEqual(data, expectedResponse);
           resolve();
@@ -390,13 +358,11 @@ suite('AuthenticatedClient', () => {
         .getOrders()
         .then(data => assert.deepEqual(data, expectedResponse));
 
-      Promise.all([cbtest, promisetest])
-        .then(() => done())
-        .catch(err => assert.ifError(err) || assert.fail());
+      return Promise.all([cbtest, promisetest]);
     });
   });
 
-  test('.getFills()', done => {
+  test('.getFills()', () => {
     const expectedResponse = [
       {
         trade_id: 74,
@@ -415,7 +381,7 @@ suite('AuthenticatedClient', () => {
     nock(EXCHANGE_API_URL).get('/fills').times(2).reply(200, expectedResponse);
 
     let cbtest = new Promise((resolve, reject) => {
-      authClient.getFills((err, response, data) => {
+      authClient.getFills((err, data) => {
         if (err) reject(err);
         assert.deepEqual(data, expectedResponse);
         resolve();
@@ -426,12 +392,10 @@ suite('AuthenticatedClient', () => {
       .getFills()
       .then(data => assert.deepEqual(data, expectedResponse));
 
-    Promise.all([cbtest, promisetest])
-      .then(() => done())
-      .catch(err => assert.ifError(err) || assert.fail());
+    return Promise.all([cbtest, promisetest]);
   });
 
-  test('.getFundings()', done => {
+  test('.getFundings()', () => {
     const expectedResponse = [
       {
         id: '280c0a56-f2fa-4d3b-a199-92df76fff5cd',
@@ -445,13 +409,10 @@ suite('AuthenticatedClient', () => {
       },
     ];
 
-    nock(EXCHANGE_API_URL)
-      .get('/funding')
-      .times(2)
-      .reply(200, expectedResponse);
+    nock(EXCHANGE_API_URL).get('/funding').times(2).reply(200, expectedResponse);
 
     let cbtest = new Promise((resolve, reject) => {
-      authClient.getFundings((err, resp, data) => {
+      authClient.getFundings((err, data) => {
         if (err) reject(err);
         assert.deepEqual(data, expectedResponse);
         resolve();
@@ -460,22 +421,19 @@ suite('AuthenticatedClient', () => {
 
     let promisetest = authClient.getFundings();
 
-    Promise.all([cbtest, promisetest])
-      .then(() => done())
-      .catch(err => assert.ifError(err) || assert.fail());
+    return Promise.all([cbtest, promisetest]);
   });
 
-  test('.repay()', function(done) {
+  test('.repay()', () => {
     const params = {
       amount: 10000,
       currency: 'USD',
     };
 
-    nock(EXCHANGE_API_URL).post('/funding/repay', params).reply(200, {});
-    nock(EXCHANGE_API_URL).post('/funding/repay', params).reply(200, {});
+    nock(EXCHANGE_API_URL).post('/funding/repay', params).times(2).reply(200, {}); // TODO mock with actual data
 
     let cbtest = new Promise((resolve, reject) => {
-      authClient.repay(params, (err, resp, data) => {
+      authClient.repay(params, (err, data) => {
         if (err) reject(err);
         resolve();
       });
@@ -483,12 +441,10 @@ suite('AuthenticatedClient', () => {
 
     let promisetest = authClient.repay(params);
 
-    Promise.all([cbtest, promisetest])
-      .then(() => done())
-      .catch(err => assert.ifError(err) || assert.fail());
+    return Promise.all([cbtest, promisetest]);
   });
 
-  test('.marginTransfer()', done => {
+  test('.marginTransfer()', () => {
     const params = {
       margin_profile_id: '45fa9e3b-00ba-4631-b907-8a98cbdf21be',
       type: 'deposit',
@@ -517,7 +473,7 @@ suite('AuthenticatedClient', () => {
       .reply(200, expectedResponse);
 
     let cbtest = new Promise((resolve, reject) => {
-      authClient.marginTransfer(params, function(err, resp, data) {
+      authClient.marginTransfer(params, function(err, data) {
         if (err) reject(err);
         assert.deepEqual(data, expectedResponse);
         resolve();
@@ -526,23 +482,18 @@ suite('AuthenticatedClient', () => {
 
     let promisetest = authClient.marginTransfer(params);
 
-    Promise.all([cbtest, promisetest])
-      .then(() => done())
-      .catch(err => assert.ifError(err) || assert.fail());
+    return Promise.all([cbtest, promisetest]);
   });
 
-  test('.closePosition()', done => {
+  test('.closePosition()', () => {
     const params = {
       repay_only: false,
     };
 
-    nock(EXCHANGE_API_URL)
-      .post('/position/close', params)
-      .times(2)
-      .reply(200, {});
+    nock(EXCHANGE_API_URL).post('/position/close', params).times(2).reply(200, {}); // TODO mock with real data
 
     let cbtest = new Promise((resolve, reject) => {
-      authClient.closePosition(params, (err, resp, data) => {
+      authClient.closePosition(params, (err, data) => {
         if (err) reject(err);
         resolve();
       });
@@ -550,12 +501,10 @@ suite('AuthenticatedClient', () => {
 
     let promisetest = authClient.closePosition(params);
 
-    Promise.all([cbtest, promisetest])
-      .then(() => done())
-      .catch(err => assert.ifError(err) || assert.fail());
+    return Promise.all([cbtest, promisetest]);
   });
 
-  test('.deposit()', done => {
+  test('.deposit()', () => {
     const transfer = {
       amount: 10480,
       coinbase_account_id: 'test-id',
@@ -567,10 +516,10 @@ suite('AuthenticatedClient', () => {
     nock(EXCHANGE_API_URL)
       .post('/transfers', expectedTransfer)
       .times(2)
-      .reply(200, {});
+      .reply(200, {}); // TODO mock with real data;
 
     let cbtest = new Promise((resolve, reject) => {
-      authClient.deposit(transfer, (err, resp, data) => {
+      authClient.deposit(transfer, (err, data) => {
         if (err) reject(err);
         resolve();
       });
@@ -578,12 +527,10 @@ suite('AuthenticatedClient', () => {
 
     let promisetest = authClient.deposit(transfer);
 
-    Promise.all([cbtest, promisetest])
-      .then(() => done())
-      .catch(err => assert.ifError(err) || assert.fail);
+    return Promise.all([cbtest, promisetest]);
   });
 
-  test('.withdraw()', done => {
+  test('.withdraw()', () => {
     const transfer = {
       amount: 10480,
       coinbase_account_id: 'test-id',
@@ -595,10 +542,10 @@ suite('AuthenticatedClient', () => {
     nock(EXCHANGE_API_URL)
       .post('/transfers', expectedTransfer)
       .times(2)
-      .reply(200, {});
+      .reply(200, {}); // TODO mock with real data
 
     let cbtest = new Promise((resolve, reject) => {
-      authClient.withdraw(transfer, (err, resp, data) => {
+      authClient.withdraw(transfer, (err, data) => {
         if (err) reject(err);
         resolve();
       });
@@ -606,8 +553,6 @@ suite('AuthenticatedClient', () => {
 
     let promisetest = authClient.withdraw(transfer);
 
-    Promise.all([cbtest, promisetest])
-      .then(() => done())
-      .catch(err => assert.ifError(err) || assert.fail());
+    return Promise.all([cbtest, promisetest]);
   });
 });

--- a/tests/public_client.spec.js
+++ b/tests/public_client.spec.js
@@ -9,7 +9,7 @@ const EXCHANGE_API_URL = 'https://api.gdax.com';
 suite('PublicClient', () => {
   afterEach(() => nock.cleanAll());
 
-  test('.getProductTrades()', done => {
+  test('.getProductTrades()', () => {
     const expectedResponse = [
       {
         time: '2014-11-07T22:19:28.578544Z',
@@ -33,7 +33,7 @@ suite('PublicClient', () => {
       .reply(200, expectedResponse);
 
     let cbtest = new Promise((resolve, reject) => {
-      publicClient.getProductTrades((err, resp, data) => {
+      publicClient.getProductTrades((err, data) => {
         if (err) reject(err);
         assert.deepEqual(data, expectedResponse);
         resolve();
@@ -44,12 +44,10 @@ suite('PublicClient', () => {
       .getProductTrades()
       .then(data => assert.deepEqual(data, expectedResponse));
 
-    Promise.all([cbtest, promisetest])
-      .then(() => done())
-      .catch(err => assert.isError(err) || assert.fail());
+    return Promise.all([cbtest, promisetest]);
   });
 
-  test('.getProductTicker() should return values', done => {
+  test('.getProductTicker() should return values', () => {
     nock(EXCHANGE_API_URL).get('/products/BTC-USD/ticker').times(2).reply(200, {
       trade_id: 'test-id',
       price: '9.00',
@@ -57,7 +55,7 @@ suite('PublicClient', () => {
     });
 
     let cbtest = new Promise((resolve, reject) => {
-      publicClient.getProductTicker((err, resp, data) => {
+      publicClient.getProductTicker((err, data) => {
         if (err) reject(err);
 
         assert.equal(data.trade_id, 'test-id');
@@ -74,9 +72,7 @@ suite('PublicClient', () => {
       assert.equal(data.size, '5');
     });
 
-    Promise.all([cbtest, promisetest])
-      .then(() => done())
-      .catch(err => assert.isError(err) || assert.fail());
+    return Promise.all([cbtest, promisetest]);
   });
 
   suite('.getProductTradeStream()', () => {
@@ -116,12 +112,9 @@ suite('PublicClient', () => {
       let current;
 
       publicClient
-        .getProductTradeStream(
-          from,
-          trade => Date.parse(trade.time) >= 1463068800000
-        )
-        .on('data', data => {
-          current = data.trade_id;
+        .getProductTradeStream(from, trade => Date.parse(trade.time) >= 1463068800000)
+        .on('data', trade => {
+          current = trade.trade_id;
           assert.equal(typeof current, 'number');
           assert.equal(
             current,


### PR DESCRIPTION
Flatten callback API from `(err, response, data)` to `(err, data)`

- Better standardize callback format to accept two parameters,
  `error` and `data`. (BREAKING CHANGE)
- Switch from `request` to `superagent` library